### PR TITLE
Add changelog for v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v4.0
 
+### v4.0.1 - 2024-07-09
+
+#### Continuous integration improvements
+
+- ci: fix setting up credentials to publish a release to npm [#30](https://github.com/2i2c-org/jupyter-launcher-shortcuts/pull/30) ([@consideRatio](https://github.com/consideRatio))
+
 ### v4.0.0 - 2024-07-09
 
 #### API and Breaking Changes


### PR DESCRIPTION
I failed to get the release automation for npm right, so we didn't get it published to npm. Going for a 4.0.1 trying to fix it with #30 merged.