### PR TITLE
Fix labextension name (jupyterlab-launcher-shortcuts, not jupyter-)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,10 +129,10 @@ jobs:
           path: jsdist
 
       - run: |
-          npm publish --dry-run ./jsdist/jupyter_launcher_shortcuts-*.tgz
+          npm publish --dry-run ./jsdist/jupyterlab-launcher-shortcuts-*.tgz
 
       - run: |
-          npm publish ./jsdist/jupyter_launcher_shortcuts-*.tgz
+          npm publish ./jsdist/jupyterlab-launcher-shortcuts-*.tgz
         if: startsWith(github.ref, 'refs/tags')
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "jupyter_launcher_shortcuts",
+    "name": "jupyterlab-launcher-shortcuts",
     "version": "4.0.1",
     "description": "Provide arbitrary shortcuts for apps in JupyterLab",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/yuvipanda/jupyter-launcher-shortcuts",
+    "homepage": "https://github.com/2i2c-org/jupyter-launcher-shortcuts",
     "bugs": {
-        "url": "https://github.com/yuvipanda/jupyter-launcher-shortcuts/issues"
+        "url": "https://github.com/2i2c-org/jupyter-launcher-shortcuts/issues"
     },
     "license": "BSD-3-Clause",
     "author": "Yuvi Panda",
@@ -23,7 +23,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/yuvipanda/jupyter-launcher-shortcuts.git"
+        "url": "https://github.com/2i2c-org/jupyter-launcher-shortcuts.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7269,9 +7269,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jupyter_launcher_shortcuts@workspace:.":
+"jupyterlab-launcher-shortcuts@workspace:.":
   version: 0.0.0-use.local
-  resolution: "jupyter_launcher_shortcuts@workspace:."
+  resolution: "jupyterlab-launcher-shortcuts@workspace:."
   dependencies:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0


### PR DESCRIPTION
The npm package wasn't named like the pypi package, it was named `jupyterlab-launcher-shortcuts` and not `jupyter_launcher_shortcuts`. This showed itself as permission errors when publishing, as i hadn't setup permissions to push to something other than `jupyterlab-launcher-shortcuts`.